### PR TITLE
Update rotor position to be consistently 1-index

### DIFF
--- a/src/com/mikepound/enigma/Rotor.java
+++ b/src/com/mikepound/enigma/Rotor.java
@@ -21,34 +21,34 @@ public class Rotor {
     public static Rotor Create(String name, int rotorPosition, int ringSetting) {
         switch (name) {
             case "I":
-                return new Rotor("I","EKMFLGDQVZNTOWYHXUSPAIBRCJ", rotorPosition, 16, ringSetting);
+                return new Rotor("I","EKMFLGDQVZNTOWYHXUSPAIBRCJ", rotorPosition, 17, ringSetting);
             case "II":
-                return new Rotor("II","AJDKSIRUXBLHWTMCQGZNPYFVOE", rotorPosition, 4, ringSetting);
+                return new Rotor("II","AJDKSIRUXBLHWTMCQGZNPYFVOE", rotorPosition, 5, ringSetting);
             case "III":
-                return new Rotor("III","BDFHJLCPRTXVZNYEIWGAKMUSQO", rotorPosition, 21, ringSetting);
+                return new Rotor("III","BDFHJLCPRTXVZNYEIWGAKMUSQO", rotorPosition, 22, ringSetting);
             case "IV":
-                return new Rotor("IV","ESOVPZJAYQUIRHXLNFTGKDCMWB", rotorPosition, 9, ringSetting);
+                return new Rotor("IV","ESOVPZJAYQUIRHXLNFTGKDCMWB", rotorPosition, 10, ringSetting);
             case "V":
-                return new Rotor("V","VZBRGITYUPSDNHLXAWMJQOFECK", rotorPosition, 25, ringSetting);
+                return new Rotor("V","VZBRGITYUPSDNHLXAWMJQOFECK", rotorPosition, 26, ringSetting);
             case "VI":
                 return new Rotor("VI","JPGVOUMFYQBENHZRDKASXLICTW", rotorPosition, 0, ringSetting) {
                     @Override
                     public boolean isAtNotch() {
-                        return this.rotorPosition == 12 || this.rotorPosition == 25;
+                        return this.rotorPosition == 13 || this.rotorPosition == 26;
                     }
                 };
             case "VII":
                 return new Rotor("VII","NZJHGRCXMYSWBOUFAIVLPEKQDT", rotorPosition, 0, ringSetting) {
                     @Override
                     public boolean isAtNotch() {
-                        return this.rotorPosition == 12 || this.rotorPosition == 25;
+                        return this.rotorPosition == 13 || this.rotorPosition == 26;
                     }
                 };
             case "VIII":
                 return new Rotor("VIII","FKQHTLXOCBJSPDZRAMEWNIUYGV", rotorPosition, 0, ringSetting) {
                     @Override
                     public boolean isAtNotch() {
-                        return this.rotorPosition == 12 || this.rotorPosition == 25;
+                        return this.rotorPosition == 13 || this.rotorPosition == 26;
                     }
                 };
             default:
@@ -100,8 +100,7 @@ public class Rotor {
     }
 
     public void turnover() {
-        this.rotorPosition = (this.rotorPosition + 1) % 26;
+        this.rotorPosition = this.rotorPosition % 26 + 1;
     }
-
 
 }


### PR DESCRIPTION
When trying out the sample text on some other enigma engines online (i.e. [this one](https://cryptii.com/pipes/enigma-machine)), the text came out slightly garbled.

Since the text was still largely correct, I figured it must have been something in the rotor rotations.

The specification of the rotor position and ring settings seem to be 1-indexed. In this project, the rotor position is maintained as 0-indexed, and also the turnover positions are kept as 0-indexed. Hence it misaligned with the 1-indexed starting position and ring setting.

---------

This change makes the rotors maintain a 1-index position consistently, without breaking the encipher method due to the modulo.